### PR TITLE
Disable mozlogrus for development

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"log"
+	"os"
+
 	"github.com/gin-gonic/gin"
 	"go.mozilla.org/mozlogrus"
 
@@ -9,13 +12,16 @@ import (
 )
 
 func setupRouter() *gin.Engine {
+	// We disable mozlogrus for development.
+	// See https://github.com/mozilla-services/go-mozlogrus/issues/2#issuecomment-330495098
+	log.SetOutput(os.Stdout)
+
 	r := gin.New()
 	// Crash free (turns errors into 5XX).
 	r.Use(gin.Recovery())
 
 	// Setup logging.
 	if gin.Mode() == gin.ReleaseMode {
-		// See https://github.com/mozilla-services/go-mozlogrus/issues/2#issuecomment-330495098
 		r.Use(MozLogger())
 		mozlogrus.Enable("iam")
 	} else {

--- a/vendor/go.mozilla.org/mozlog/mozlog.go
+++ b/vendor/go.mozilla.org/mozlog/mozlog.go
@@ -34,8 +34,7 @@ func init() {
 		log.Printf("Can't resolve hostname: %v", err)
 	}
 
-	// See https://github.com/mozilla-services/go-mozlogrus/issues/2#issuecomment-330495098
-	// log.SetOutput(Logger)
+	log.SetOutput(Logger)
 	log.SetFlags(log.Lshortfile)
 }
 


### PR DESCRIPTION
This commit removes the hack in mozlog vendor that can be accidentally
lost (especially using glide)

See https://github.com/mozilla-services/go-mozlogrus/issues/2#issuecomment-330495098