### PR TITLE
Remove subject notion from REAME and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Policies are defined in YAML file (default ``./policies.yaml``) as follow:
   policies:
     -
       description: One policy to rule them all.
-      subjects:
+      principals:
         - userid:<[peter|ken]>
         - tag:admins
         - group:europe

--- a/README.md
+++ b/README.md
@@ -86,16 +86,16 @@ conditions:
       matches: blocklists-.*
 ```
 
-**Subject comparison**
+**In principals**
 
-* type: ``EqualsSubjectCondition``
+* type: ``InPrincipalsCondition``
 
-For example, allow requests where ``request.context["owner"] == request.subject``:
+For example, allow requests where ``request.context["owner"]`` is in principals:
 
 ```yaml
 conditions:
   owner:
-    type: EqualsSubjectCondition
+    type: InPrincipalsCondition
 ```
 
 **IP/Range**

--- a/doorman/doorman_ladon_condition_principals.go
+++ b/doorman/doorman_ladon_condition_principals.go
@@ -1,0 +1,27 @@
+package doorman
+
+import (
+    "github.com/ory/ladon"
+)
+
+// InPrincipalsCondition is a condition which is fulfilled if the given value string is among principals.
+type InPrincipalsCondition struct{}
+
+// Fulfills returns true if the request's subject is equal to the given value string.
+// This makes sense only because we iterate on principals and set the Request subject.
+func (c *InPrincipalsCondition) Fulfills(value interface{}, r *ladon.Request) bool {
+    s, ok := value.(string)
+
+    return ok && s == r.Subject
+}
+
+// GetName returns the condition's name.
+func (c *InPrincipalsCondition) GetName() string {
+    return "InPrincipalsCondition"
+}
+
+func init() {
+    ladon.ConditionFactories[new(InPrincipalsCondition).GetName()] = func() ladon.Condition {
+        return new(InPrincipalsCondition)
+    }
+}

--- a/doorman/doorman_ladon_condition_principals.go
+++ b/doorman/doorman_ladon_condition_principals.go
@@ -1,7 +1,7 @@
 package doorman
 
 import (
-    "github.com/ory/ladon"
+	"github.com/ory/ladon"
 )
 
 // InPrincipalsCondition is a condition which is fulfilled if the given value string is among principals.
@@ -10,18 +10,18 @@ type InPrincipalsCondition struct{}
 // Fulfills returns true if the request's subject is equal to the given value string.
 // This makes sense only because we iterate on principals and set the Request subject.
 func (c *InPrincipalsCondition) Fulfills(value interface{}, r *ladon.Request) bool {
-    s, ok := value.(string)
+	s, ok := value.(string)
 
-    return ok && s == r.Subject
+	return ok && s == r.Subject
 }
 
 // GetName returns the condition's name.
 func (c *InPrincipalsCondition) GetName() string {
-    return "InPrincipalsCondition"
+	return "InPrincipalsCondition"
 }
 
 func init() {
-    ladon.ConditionFactories[new(InPrincipalsCondition).GetName()] = func() ladon.Condition {
-        return new(InPrincipalsCondition)
-    }
+	ladon.ConditionFactories[new(InPrincipalsCondition).GetName()] = func() ladon.Condition {
+		return new(InPrincipalsCondition)
+	}
 }

--- a/doorman/doorman_ladon_test.go
+++ b/doorman/doorman_ladon_test.go
@@ -173,7 +173,7 @@ func TestLoadGithub(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// Good URL
-	w = New([]string{"https://github.com/leplatrem/iam/raw/06a2531/sample.yaml"})
+	w = New([]string{"https://github.com/leplatrem/iam/raw/f83dd7e/sample.yaml"})
 	err = w.LoadPolicies()
 	assert.Nil(t, err)
 	assert.Equal(t, len(w.configs["https://sample.yaml"].Tags), 1)

--- a/sample.yaml
+++ b/sample.yaml
@@ -55,7 +55,7 @@ policies:
       - <.*>
     conditions:
       owner:
-        type: EqualsSubjectCondition
+        type: InPrincipalsCondition
     effect: allow
   -
     id: "5"

--- a/sample.yaml
+++ b/sample.yaml
@@ -6,7 +6,7 @@ policies:
   -
     id: "1"
     description: This policy allows 'userid:foo' to update any resource
-    subjects:
+    principals:
       - userid:foo
       - tag:admins
     actions:
@@ -17,7 +17,7 @@ policies:
   -
     id: "2"
     description: This policy rejects everything from planet mars
-    subjects:
+    principals:
       - <.*>
     actions:
       - <.*>
@@ -32,7 +32,7 @@ policies:
   -
     id: "3"
     description: This policy allow read from localhost
-    subjects:
+    principals:
       - <.*>
     actions:
       - read
@@ -47,7 +47,7 @@ policies:
   -
     id: "4"
     description: Only owner
-    subjects:
+    principals:
       - <.*>
     actions:
       - <.*>
@@ -60,7 +60,7 @@ policies:
   -
     id: "5"
     description: Admins on Mozilla domain
-    subjects:
+    principals:
       - group:admins
     actions:
       - create
@@ -75,7 +75,7 @@ policies:
   -
     id: "6"
     description: Editors can update PTO
-    subjects:
+    principals:
       - role:editor
     actions:
       - update


### PR DESCRIPTION
Since we use principals, we want to keep the notion of `subject` internal to ladon