### PR TITLE
Rename audience to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Doorman
 Policies are defined in YAML files for each service, locally or in remote Github repos, as follow:
 
 ```yaml
-audience: https://service.stage.net
+service: https://service.stage.net
 jwtIssuer: https://auth.mozilla.auth0.com/
 tags:
   superusers:
@@ -46,7 +46,7 @@ policies:
     effect: allow
 ```
 
-* **audience**: the unique identifier of the service
+* **service**: the unique identifier of the service
 * **jwtIssuer** (*optional*): when the issuer is set, *Doorman* will verify the JSON Web Token provided in the authorization request and extract the Identity Provider information from its payload
 * **tags**: Local «groups» of principals in addition to the ones provided by the Identity Provider
 * **actions**: a domain-specific string representing an action that will be defined as allowed by a principal (eg. `publish`, `signoff`, …)
@@ -102,7 +102,7 @@ resources:
 
 The conditions are **optional** on policies and are used to match field values from the authorization request context.
 
-The context values ``remoteIP`` and ``audience`` are forced by the server.
+The context values ``remoteIP`` and ``service`` are forced by the server.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ resources:
 
 The conditions are **optional** on policies and are used to match field values from the authorization request context.
 
-The context values ``remoteIP`` and ``service`` are forced by the server.
+The context value ``remoteIP`` is forced by the server.
 
 For example:
 

--- a/doorman/doorman.go
+++ b/doorman/doorman.go
@@ -43,9 +43,9 @@ type Doorman interface {
 	// LoadPolicies is responsible for reading and loading the policies files.
 	LoadPolicies() error
 	// JWTValidator
-	JWTValidator(audience string) (JWTValidator, error)
+	JWTValidator(service string) (JWTValidator, error)
 	// ExpandPrincipals looks up and add extra principals to the ones specified.
-	ExpandPrincipals(audience string, principals Principals) Principals
+	ExpandPrincipals(service string, principals Principals) Principals
 	// IsAllowed is responsible for deciding if subject can perform action on a resource with a context.
-	IsAllowed(audience string, request *Request) bool
+	IsAllowed(service string, request *Request) bool
 }

--- a/doorman/doorman_ladon_auditlogger.go
+++ b/doorman/doorman_ladon_auditlogger.go
@@ -34,9 +34,9 @@ func (a *auditLogger) logRequest(allowed bool, r *ladon.Request, policies ladon.
 	var remoteIP string
 	context := map[string]interface{}{}
 	for k, v := range r.Context {
-		if k == "principals" {
+		if k == "_principals" {
 			principals = v.(Principals)
-		} else if k == "service" {
+		} else if k == "_service" {
 			service = v.(string)
 		} else if k == "remoteIP" {
 			remoteIP = v.(string)
@@ -63,7 +63,7 @@ func (a *auditLogger) logRequest(allowed bool, r *ladon.Request, policies ladon.
 func (a *auditLogger) LogRejectedAccessRequest(request *ladon.Request, pool ladon.Policies, deciders ladon.Policies) {
 	// Since we iterate on principals to test individual subjects, when a request is denied
 	// we want to log the last one only, ie. when r.subject == last(principals)
-	principals := request.Context["principals"].(Principals)
+	principals := request.Context["_principals"].(Principals)
 	if request.Subject != principals[len(principals)-1] {
 		return
 	}

--- a/doorman/doorman_ladon_auditlogger.go
+++ b/doorman/doorman_ladon_auditlogger.go
@@ -30,14 +30,14 @@ func (a *auditLogger) logRequest(allowed bool, r *ladon.Request, policies ladon.
 
 	// Remove custom values out of context for nicer logging (were set in handler)
 	var principals Principals
-	var audience string
+	var service string
 	var remoteIP string
 	context := map[string]interface{}{}
 	for k, v := range r.Context {
 		if k == "principals" {
 			principals = v.(Principals)
-		} else if k == "audience" {
-			audience = v.(string)
+		} else if k == "service" {
+			service = v.(string)
 		} else if k == "remoteIP" {
 			remoteIP = v.(string)
 		} else {
@@ -49,7 +49,7 @@ func (a *auditLogger) logRequest(allowed bool, r *ladon.Request, policies ladon.
 		logrus.Fields{
 			"allowed":    allowed,
 			"principals": principals,
-			"audience":   audience,
+			"service":    service,
 			"remoteIP":   remoteIP,
 			"policies":   policiesNames,
 			"action":     r.Action,

--- a/doorman/doorman_ladon_loader_file.go
+++ b/doorman/doorman_ladon_loader_file.go
@@ -87,15 +87,15 @@ func loadFile(filename string) (*Configuration, error) {
 		return nil, err
 	}
 
-	if config.Audience == "" {
-		return nil, fmt.Errorf("empty audience in %q", filename)
+	if config.Service == "" {
+		return nil, fmt.Errorf("empty service in %q", filename)
 	}
 
 	if len(config.Policies) == 0 {
 		log.Warningf("No policies found in %q", filename)
 	}
 
-	log.Infof("Found audience %q", config.Audience)
+	log.Infof("Found service %q", config.Service)
 	log.Infof("Found %d tags", len(config.Tags))
 	log.Infof("Found %d policies", len(config.Policies))
 

--- a/doorman/doorman_ladon_test.go
+++ b/doorman/doorman_ladon_test.go
@@ -357,7 +357,7 @@ func TestDoormanNotAllowed(t *testing.T) {
 		},
 	} {
 		// Force context value like in handler.
-		request.Context["principals"] = request.Principals
+		request.Context["_principals"] = request.Principals
 		assert.Equal(t, false, doorman.IsAllowed("https://sample.yaml", request))
 	}
 }
@@ -384,8 +384,8 @@ func TestDoormanAuditLogger(t *testing.T) {
 		Action:     "any",
 		Resource:   "any",
 		Context: Context{
-			"planet":     "mars",
-			"principals": Principals{"userid:any"},
+			"planet":      "mars",
+			"_principals": Principals{"userid:any"},
 		},
 	})
 	assert.Contains(t, buf.String(), "\"allowed\":false")

--- a/doorman/doorman_ladon_test.go
+++ b/doorman/doorman_ladon_test.go
@@ -184,7 +184,7 @@ func TestLoadGithub(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// Good URL
-	w = New([]string{"https://github.com/leplatrem/iam/raw/f83dd7e/sample.yaml"})
+	w = New([]string{"https://github.com/leplatrem/iam/raw/4704cc9/sample.yaml"})
 	err = w.LoadPolicies()
 	assert.Nil(t, err)
 	assert.Equal(t, len(w.configs["https://sample.yaml"].Tags), 1)

--- a/doorman/doorman_ladon_test.go
+++ b/doorman/doorman_ladon_test.go
@@ -52,9 +52,9 @@ func TestLoadBadPolicies(t *testing.T) {
 	_, err = loadTempFiles("$\\--xx")
 	assert.NotNil(t, err)
 
-	// Empty audience
+	// Empty service
 	_, err = loadTempFiles(`
-audience:
+service:
 policies:
   -
     id: "1"
@@ -64,14 +64,14 @@ policies:
 
 	// Empty policies
 	_, err = loadTempFiles(`
-audience: a
+service: a
 policies:
 `)
 	assert.Nil(t, err)
 
-	// Bad audience
+	// Bad service
 	_, err = loadTempFiles(`
-audience: 1
+service: 1
 policies:
   -
     id: "1"
@@ -81,7 +81,7 @@ policies:
 
 	// Bad policies conditions
 	_, err = loadTempFiles(`
-audience: a
+service: a
 policies:
   -
     id: "1"
@@ -93,7 +93,7 @@ policies:
 
 	// Duplicated policy ID
 	_, err = loadTempFiles(`
-audience: a
+service: a
 policies:
   -
     id: "1"
@@ -104,15 +104,15 @@ policies:
 `)
 	assert.NotNil(t, err)
 
-	// Duplicated audience
+	// Duplicated service
 	_, err = loadTempFiles(`
-audience: a
+service: a
 policies:
   -
     id: "1"
     effect: allow
 `, `
-audience: a
+service: a
 policies:
   -
     id: "1"
@@ -122,7 +122,7 @@ policies:
 
 	// Bad JWT issuer
 	_, err = loadTempFiles(`
-audience: a
+service: a
 jwtIssuer: https://perlin-pinpin
 policies:
   -
@@ -146,7 +146,7 @@ func TestLoadFolder(t *testing.T) {
 	testfile := filepath.Join(dir, "test.yaml")
 	defer os.Remove(testfile)
 	err = ioutil.WriteFile(testfile, []byte(`
-audience: a
+service: a
 policies:
   -
     id: "1"
@@ -193,7 +193,7 @@ func TestLoadGithub(t *testing.T) {
 
 func TestLoadTags(t *testing.T) {
 	d, err := loadTempFiles(`
-audience: a
+service: a
 tags:
   admins:
     - alice@mit.edu
@@ -238,10 +238,10 @@ func TestIsAllowed(t *testing.T) {
 		Resource:   "server.org/blocklist:onecrl",
 	}
 
-	// Check audience
+	// Check service
 	allowed := doorman.IsAllowed("https://sample.yaml", request)
 	assert.True(t, allowed)
-	allowed = doorman.IsAllowed("https://bad.audience", request)
+	allowed = doorman.IsAllowed("https://bad.service", request)
 	assert.False(t, allowed)
 }
 
@@ -371,15 +371,15 @@ func TestDoormanAuditLogger(t *testing.T) {
 		doorman.auditLogger().logger.Out = os.Stdout
 	}()
 
-	// Logs when audience is bad.
-	doorman.IsAllowed("bad audience", &Request{})
+	// Logs when service is bad.
+	doorman.IsAllowed("bad service", &Request{})
 	assert.Contains(t, buf.String(), "\"allowed\":false")
 
-	audience := "https://sample.yaml"
+	service := "https://sample.yaml"
 
 	// Logs policies.
 	buf.Reset()
-	doorman.IsAllowed(audience, &Request{
+	doorman.IsAllowed(service, &Request{
 		Principals: Principals{"userid:any"},
 		Action:     "any",
 		Resource:   "any",
@@ -392,7 +392,7 @@ func TestDoormanAuditLogger(t *testing.T) {
 	assert.Contains(t, buf.String(), "\"policies\":[\"2\"]")
 
 	buf.Reset()
-	doorman.IsAllowed(audience, &Request{
+	doorman.IsAllowed(service, &Request{
 		Principals: Principals{"userid:foo"},
 		Action:     "update",
 		Resource:   "server.org/blocklist:onecrl",

--- a/doorman/handler.go
+++ b/doorman/handler.go
@@ -33,7 +33,7 @@ func allowedHandler(c *gin.Context) {
 		return
 	}
 
-	// Is JWT verification enable for this audience?
+	// Is JWT verification enable for this service?
 	// If disabled (like in tests), principals can be posted in JSON.
 	jwtPrincipals, ok := c.Get(PrincipalsContextKey)
 	if ok {
@@ -54,10 +54,10 @@ func allowedHandler(c *gin.Context) {
 	}
 
 	doorman := c.MustGet(DoormanContextKey).(Doorman)
-	audience := c.Request.Header.Get("Origin")
+	service := c.Request.Header.Get("Origin")
 
 	// Expand principals with local ones.
-	r.Principals = doorman.ExpandPrincipals(audience, r.Principals)
+	r.Principals = doorman.ExpandPrincipals(service, r.Principals)
 	// Expand principals with specified roles.
 	r.Principals = append(r.Principals, r.Roles()...)
 
@@ -67,11 +67,11 @@ func allowedHandler(c *gin.Context) {
 	if r.Context == nil {
 		r.Context = Context{}
 	}
-	r.Context["audience"] = audience
+	r.Context["service"] = service
 	r.Context["remoteIP"] = c.Request.RemoteAddr
 	r.Context["principals"] = r.Principals
 
-	allowed := doorman.IsAllowed(audience, &r)
+	allowed := doorman.IsAllowed(service, &r)
 
 	c.JSON(http.StatusOK, gin.H{
 		"allowed":    allowed,

--- a/doorman/handler.go
+++ b/doorman/handler.go
@@ -67,9 +67,9 @@ func allowedHandler(c *gin.Context) {
 	if r.Context == nil {
 		r.Context = Context{}
 	}
-	r.Context["service"] = service
 	r.Context["remoteIP"] = c.Request.RemoteAddr
-	r.Context["principals"] = r.Principals
+	r.Context["_service"] = service
+	r.Context["_principals"] = r.Principals
 
 	allowed := doorman.IsAllowed(service, &r)
 

--- a/doorman/handler_test.go
+++ b/doorman/handler_test.go
@@ -59,7 +59,7 @@ func TestAllowedVerifiesJWT(t *testing.T) {
 	tmpfile, _ := ioutil.TempFile("", "")
 	defer os.Remove(tmpfile.Name()) // clean up
 	tmpfile.Write([]byte(`
-audience: https://sample.yaml
+service: https://sample.yaml
 jwtIssuer: https://auth.mozilla.auth0.com/
 policies:
   -
@@ -202,7 +202,7 @@ func TestReloadHandler(t *testing.T) {
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	tmpfile.Write([]byte(`
-audience: a
+service: a
 policies:
   -
     id: "1"

--- a/doorman/middleware.go
+++ b/doorman/middleware.go
@@ -25,7 +25,7 @@ func ContextMiddleware(doorman Doorman) gin.HandlerFunc {
 func VerifyJWTMiddleware(doorman Doorman) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// The service requesting must send its location. It will be compared
-		// with the audiences defined in policies files.
+		// with the services defined in policies files.
 		// XXX: The Origin request header might not be the best choice.
 		origin := c.Request.Header.Get("Origin")
 		if origin == "" {

--- a/sample.yaml
+++ b/sample.yaml
@@ -1,4 +1,4 @@
-audience: https://sample.yaml
+service: https://sample.yaml
 tags:
   admins:
     - userid:maria

--- a/utilities/openapi.yaml
+++ b/utilities/openapi.yaml
@@ -112,9 +112,9 @@ paths:
           name: Origin
           type: string
           description: |
-            The service identifier (eg. `https://api.service.org`). It must match one of the known audience from the policies files.
+            The service identifier (eg. `https://api.service.org`). It must match one of the known service from the policies files.
 
-            With JWT verification enabled, the claimed audience in the JWT will be checked against this header.
+            With JWT verification enabled, the claimed audience in the JWT will be checked against the value of this header.
 
         - in: header
           name: Authorization
@@ -151,7 +151,7 @@ paths:
               context:
                 description: |
                   The context can contain any extra information to be matched in policies conditions.
-                  The context fields `remoteIP` and `audience` will be forced by the server.
+                  The context field `remoteIP` will be forced by the server.
                   The values provided in the `roles` context field will expand the principals with extra `role:{}` values.
 
                 type: object


### PR DESCRIPTION
I think it makes more sense, `audience` is the vocabulary of auth

@Natim r?